### PR TITLE
Python 3 compatibility.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(name='expecter',
       version='0.2.1',
       description='Expecter Gadget, a better expectation (assertion) library',
-      long_description=file('README.txt').read(),
+      long_description=open('README.txt').read(),
       author='Gary Bernhardt',
       author_email='gary.bernhardt@gmail.com',
       py_modules=['expecter'],

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,6 +1,6 @@
 def fail_msg(callable_):
     try:
         callable_()
-    except Exception,e :
+    except Exception as e:
         return str(e)
 


### PR DESCRIPTION
Love `expecter`, so shockingly simple and concise!

---

Included is a very minor fix for use with Python 3.  This breaks Python < 2.5 compat, but the tests didn't pass before hand so perhaps that isn't an issue?

Thanks,

James
