### PR TITLE
Drastically alter the syntax for a slight improvement in readability

### DIFF
--- a/expecter.py
+++ b/expecter.py
@@ -6,6 +6,9 @@ class expect(object):
         self._actual = actual
 
     def __getattr__(self, name):
+        if name == 'to':
+            return self
+
         is_custom_expectation = name in _custom_expectations
         if is_custom_expectation:
             predicate = _custom_expectations[name]
@@ -50,17 +53,17 @@ class expect(object):
     def __repr__(self):
         return 'expect(%s)' % repr(self._actual)
 
-    def isinstance(self, expected_cls):
+    def be_instance_of(self, expected_cls):
         assert isinstance(self._actual, expected_cls), (
             'Expected an instance of %s but got an instance of %s' % (
                 expected_cls.__name__, self._actual.__class__.__name__))
 
-    def contains(self, other):
+    def contain(self, other):
         assert other in self._actual, (
             "Expected %s to contain %s but it didn't" % (
                 repr(self._actual), repr(other)))
 
-    def does_not_contain(self, other):
+    def not_contain(self, other):
         assert other not in self._actual, (
             "Expected %s to not contain %s but it did" % (
                 repr(self._actual), repr(other)))

--- a/tests/test_expecter.py
+++ b/tests/test_expecter.py
@@ -7,42 +7,42 @@ from expecter import expect
 
 class describe_expecter:
     def it_expects_equals(self):
-        expect(2) == 1 + 1
-        def _fails(): expect(1) == 2
+        expect(2).to == 1 + 1
+        def _fails(): expect(1).to == 2
         assert_raises(AssertionError, _fails)
         assert fail_msg(_fails) == 'Expected 2 but got 1'
 
     def it_expects_not_equals(self):
-        expect(1) != 2
-        def _fails(): expect(1) != 1
+        expect(1).to != 2
+        def _fails(): expect(1).to != 1
         assert_raises(AssertionError, _fails)
         assert fail_msg(_fails) == 'Expected anything except 1 but got it'
 
     def it_expects_less_than(self):
-        expect(1) < 2
-        def _fails(): expect(1) < 0
+        expect(1).to < 2
+        def _fails(): expect(1).to < 0
         assert_raises(AssertionError, _fails)
         assert fail_msg(_fails) == 'Expected something less than 0 but got 1'
 
     def it_expects_greater_than(self):
-        expect(2) > 1
-        def _fails(): expect(0) > 1
+        expect(2).to > 1
+        def _fails(): expect(0).to > 1
         assert_raises(AssertionError, _fails)
         assert fail_msg(_fails) == (
             'Expected something greater than 1 but got 0')
 
     def it_expects_less_than_or_equal(self):
-        expect(1) <= 1
-        expect(1) <= 2
-        def _fails(): expect(2) <= 1
+        expect(1).to <= 1
+        expect(1).to <= 2
+        def _fails(): expect(2).to <= 1
         assert_raises(AssertionError, _fails)
         assert fail_msg(_fails) == (
             'Expected something less than or equal to 1 but got 2')
 
     def it_expects_greater_than_or_equal(self):
-        expect(1) >= 1
-        expect(2) >= 1
-        def _fails(): expect(1) >= 2
+        expect(1).to >= 1
+        expect(2).to >= 1
+        def _fails(): expect(1).to >= 2
         assert_raises(AssertionError, _fails)
         assert fail_msg(_fails) == (
             'Expected something greater than or equal to 2 but got 1')
@@ -50,12 +50,12 @@ class describe_expecter:
     def it_can_chain_comparison_expectations(self):
         # In each of these chains, the first expectation passes and the second
         # fails. This forces the first expectation to return self.
-        failing_chains = [lambda: 1 == expect(1) != 1,
-                          lambda: 1 != expect(2) != 2,
-                          lambda: 1 < expect(2) != 2,
-                          lambda: 1 > expect(0) != 0,
-                          lambda: 1 <= expect(1) != 1,
-                          lambda: 1 >= expect(1) != 1]
+        failing_chains = [lambda: 1 == expect(1).to != 1,
+                          lambda: 1 != expect(2).to != 2,
+                          lambda: 1 < expect(2).to != 2,
+                          lambda: 1 > expect(0).to != 0,
+                          lambda: 1 <= expect(1).to != 1,
+                          lambda: 1 >= expect(1).to != 1]
         for chain in failing_chains:
             assert_raises(AssertionError, chain)
 
@@ -64,25 +64,25 @@ class describe_expecter:
         del chain
 
     def it_expects_isinstance(self):
-        expect(1).isinstance(int)
+        expect(1).to.be_instance_of(int)
         def _fails():
-            expect(1).isinstance(str)
+            expect(1).to.be_instance_of(str)
         assert_raises(AssertionError, _fails)
         assert fail_msg(_fails) == (
             'Expected an instance of str but got an instance of int')
 
     def it_expects_containment(self):
-        expect([1]).contains(1)
+        expect([1]).to.contain(1)
         def _fails():
-            expect([2]).contains(1)
+            expect([2]).to.contain(1)
         assert_raises(AssertionError, _fails)
         assert fail_msg(_fails) == (
             "Expected [2] to contain 1 but it didn't")
 
     def it_expects_non_containment(self):
-        expect([1]).does_not_contain(0)
+        expect([1]).to.not_contain(0)
         def _fails():
-            expect([1]).does_not_contain(1)
+            expect([1]).to.not_contain(1)
         assert_raises(AssertionError, _fails)
         assert fail_msg(_fails) == (
             "Expected [1] to not contain 1 but it did")


### PR DESCRIPTION
Because I'm a Ruby developer, and that's what we do.

Perhaps `.to_not_contain` would be superior to `.to.not_contain`, but hey, this isn't too serious.
