### PR TITLE
Allow isinstance to take multiple classes.

### DIFF
--- a/expecter.py
+++ b/expecter.py
@@ -75,9 +75,14 @@ class expect(object):
         """
         Ensures that the actual value is of type ``expected_cls`` (like ``assert isinstance(actual, MyClass)``).
         """
+        if isinstance(expected_cls, tuple):
+            cls_name = [c.__name__ for c in expected_cls]
+            cls_name = ' or '.join(cls_name)
+        else:
+            cls_name = expected_cls.__name__
         assert isinstance(self._actual, expected_cls), (
             'Expected an instance of %s but got an instance of %s' % (
-                expected_cls.__name__, self._actual.__class__.__name__))
+                cls_name, self._actual.__class__.__name__))
 
     def contains(self, other):
         """
@@ -214,3 +219,4 @@ def add_expectation(predicate):
 def clear_expectations():
     """Remove all custom expectations"""
     _custom_expectations.clear()
+

--- a/tests/unit/test_expecter.py
+++ b/tests/unit/test_expecter.py
@@ -86,4 +86,3 @@ class describe_expecter:
         assert_raises(AssertionError, _fails)
         assert fail_msg(_fails) == (
             "Expected [1] to not contain 1 but it did")
-

--- a/tests/unit/test_expecter.py
+++ b/tests/unit/test_expecter.py
@@ -71,6 +71,14 @@ class describe_expecter:
         assert fail_msg(_fails) == (
             'Expected an instance of str but got an instance of int')
 
+    def it_expects_isintance_multi(self):
+        expect('str').isinstance((str, bytes))
+        def _fails():
+            expect('str').isinstance((int, long))
+        assert_raises(AssertionError, _fails)
+        assert fail_msg(_fails) == (
+            'Expected an instance of int or long but got an instance of str')
+
     def it_expects_containment(self):
         expect([1]).contains(1)
         def _fails():


### PR DESCRIPTION
e.g.

``` python
expect('str').isinstance((str, bytes))
```
