### PR TITLE
Implemented the showing of a Diff for differing strings, like Rspec does.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - 3.2
   - 3.3
 install:
-  - pip install --use-mirrors nose
+  - pip install --use-mirrors sphinx
   - pip install --use-mirrors .
 script:
   - ./runtests.py

--- a/expecter.py
+++ b/expecter.py
@@ -1,4 +1,5 @@
 __all__ = ['expect']
+import difflib
 
 
 class expect(object):
@@ -35,8 +36,13 @@ class expect(object):
             return getattr(super(expect, self), name)
 
     def __eq__(self, other):
-        assert self._actual == other, (
-            'Expected %s but got %s' % (repr(other), repr(self._actual)))
+        msg = 'Expected %s but got %s' % (repr(other), repr(self._actual))
+        if isinstance(other, str) and isinstance(self._actual, str):
+            diff = difflib.unified_diff(other.split('\n'),
+                    self._actual.split('\n'),
+                    lineterm='')
+            msg = '\n'.join([msg, 'Diff:'] + list(diff)[2:])
+        assert self._actual == other, msg
         return self
 
     def __ne__(self, other):

--- a/expecter.py
+++ b/expecter.py
@@ -1,6 +1,14 @@
 __all__ = ['expect']
 import difflib
 
+try:
+    import builtins as __builtins__
+except ImportError:
+    import __builtin__ as __builtins__
+
+
+basestring = getattr(__builtins__, 'basestring', (str, bytes))
+
 
 class expect(object):
     """
@@ -36,7 +44,7 @@ class expect(object):
             return getattr(super(expect, self), name)
 
     def __eq__(self, other):
-        msg = u'Expected %s but got %s' % (repr(other), repr(self._actual))
+        msg = 'Expected %s but got %s' % (repr(other), repr(self._actual))
         if isinstance(other, basestring) and isinstance(self._actual,
                 basestring):
             msg += normalized_diff(other, self._actual)
@@ -226,10 +234,8 @@ def clear_expectations():
 
 
 def normalized_diff(other, actual):
-    other = other.encode('utf-8')
-    actual = actual.encode('utf-8')
     diff = difflib.unified_diff(other.split('\n'),
             actual.split('\n'),
             lineterm='')
     diff = list(diff)
-    return '\n'.join(['\nDiff:'] + diff[2:]).decode('utf-8')
+    return '\n'.join(['\nDiff:'] + diff[2:])

--- a/expecter.py
+++ b/expecter.py
@@ -36,12 +36,10 @@ class expect(object):
             return getattr(super(expect, self), name)
 
     def __eq__(self, other):
-        msg = 'Expected %s but got %s' % (repr(other), repr(self._actual))
-        if isinstance(other, str) and isinstance(self._actual, str):
-            diff = difflib.unified_diff(other.split('\n'),
-                    self._actual.split('\n'),
-                    lineterm='')
-            msg = '\n'.join([msg, 'Diff:'] + list(diff)[2:])
+        msg = u'Expected %s but got %s' % (repr(other), repr(self._actual))
+        if isinstance(other, basestring) and isinstance(self._actual,
+                basestring):
+            msg += normalized_diff(other, self._actual)
         assert self._actual == other, msg
         return self
 
@@ -226,3 +224,12 @@ def clear_expectations():
     """Remove all custom expectations"""
     _custom_expectations.clear()
 
+
+def normalized_diff(other, actual):
+    other = other.encode('utf-8')
+    actual = actual.encode('utf-8')
+    diff = difflib.unified_diff(other.split('\n'),
+            actual.split('\n'),
+            lineterm='')
+    diff = list(diff)
+    return '\n'.join(['\nDiff:'] + diff[2:]).decode('utf-8')

--- a/tests/unit/test_expecter.py
+++ b/tests/unit/test_expecter.py
@@ -21,7 +21,19 @@ class describe_expecter:
                " foo\n"
                "-baz\n"
                "+bar"
-               ), repr(fail_msg(_fails))
+               )
+
+    def it_shows_diff_when_unicode_strings_differ(self):
+        def _fails(): expect(u'ueber\ngeek') == u'\xfcber\ngeek'
+        assert_raises(AssertionError, _fails)
+        assert fail_msg(_fails) == (
+               u"Expected u'\\xfcber\\ngeek' but got u'ueber\\ngeek'\n"
+               "Diff:\n"
+               "@@ -1,2 +1,2 @@\n"
+               u"-\xfcber\n"
+               "+ueber\n"
+               " geek"
+               )
 
     def it_expects_not_equals(self):
         expect(1) != 2

--- a/tests/unit/test_expecter.py
+++ b/tests/unit/test_expecter.py
@@ -21,19 +21,7 @@ class describe_expecter:
                " foo\n"
                "-baz\n"
                "+bar"
-               )
-
-    def it_shows_diff_when_unicode_strings_differ(self):
-        def _fails(): expect(u'ueber\ngeek') == u'\xfcber\ngeek'
-        assert_raises(AssertionError, _fails)
-        assert fail_msg(_fails) == (
-               u"Expected u'\\xfcber\\ngeek' but got u'ueber\\ngeek'\n"
-               "Diff:\n"
-               "@@ -1,2 +1,2 @@\n"
-               u"-\xfcber\n"
-               "+ueber\n"
-               " geek"
-               )
+               ), fail_msg(_fails)
 
     def it_expects_not_equals(self):
         expect(1) != 2

--- a/tests/unit/test_expecter.py
+++ b/tests/unit/test_expecter.py
@@ -12,6 +12,17 @@ class describe_expecter:
         assert_raises(AssertionError, _fails)
         assert fail_msg(_fails) == 'Expected 2 but got 1'
 
+    def it_shows_diff_when_strings_differ(self):
+        def _fails(): expect('foo\nbar') == 'foo\nbaz'
+        assert_raises(AssertionError, _fails)
+        assert fail_msg(_fails) == ("Expected 'foo\\nbaz' but got 'foo\\nbar'\n"
+               "Diff:\n"
+               "@@ -1,2 +1,2 @@\n"
+               " foo\n"
+               "-baz\n"
+               "+bar"
+               ), repr(fail_msg(_fails))
+
     def it_expects_not_equals(self):
         expect(1) != 2
         def _fails(): expect(1) != 1

--- a/tests/unit/test_unicode.py
+++ b/tests/unit/test_unicode.py
@@ -1,0 +1,34 @@
+# vim: set fileencoding=utf-8 :
+from __future__ import unicode_literals
+from nose.tools import assert_raises
+
+from tests.util import fail_msg
+from expecter import expect
+
+try:
+    import builtins as __builtins__
+except ImportError:
+    import __builtin__ as __builtins__
+
+unicode = getattr(__builtins__, 'unicode', str)
+
+class describe_expecter:
+    def it_shows_diff_when_unicode_strings_differ(self):
+        value = 'ueber\ngeek'
+        fixture = 'über\ngeek'
+        assert isinstance(value, unicode), "value is a " + repr(type(value))
+        assert isinstance(fixture, unicode), "fixture is a " + repr(type(fixture))
+        def _fails(): expect(value) == fixture
+        assert_raises(AssertionError, _fails)
+        msg = ("Expected 'über\\ngeek' but got 'ueber\\ngeek'\n"
+               "Diff:\n"
+               "@@ -1,2 +1,2 @@\n"
+               "-über\n"
+               "+ueber\n"
+               " geek"
+               )
+        #normalize real msg for differences in py2 and py3
+        real = fail_msg(_fails).replace("u'", "'").replace(
+                '\\xfc', '\xfc')
+        assert  real == msg, '\n' + repr(real) + '\n' + repr(msg)
+

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,5 +2,5 @@ def fail_msg(callable_):
     try:
         callable_()
     except Exception as e:
-        return str(e)
+        return unicode(e)
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,6 +1,13 @@
+try:
+    import builtins as __builtins__
+except ImportError:
+    import __builtin__ as __builtins__
+
+str = getattr(__builtins__, 'unicode', str)
+
 def fail_msg(callable_):
     try:
         callable_()
     except Exception as e:
-        return unicode(e)
+        return str(e)
 


### PR DESCRIPTION
https://github.com/garybernhardt/expecter/issues/3

Works for strings and unicode.

Points of attention:
- Might break in Python 3 I have only tested it in 2.7
- Now that I read the issue again, perhaps I should test for newlines, right now a diff is shown for all failing str's and unicode's, not just long ones.

Let me know what you think.
