### PR TITLE
Pass arguments to custom expectations.

### DIFF
--- a/expecter.py
+++ b/expecter.py
@@ -186,11 +186,11 @@ class _CustomExpectation:
         self._predicate = predicate
         self._actual = actual
 
-    def __call__(self):
-        self.enforce()
+    def __call__(self, *args, **kwargs):
+        self.enforce(*args, **kwargs)
 
-    def enforce(self):
-        if not self._predicate(self._actual):
+    def enforce(self, *args, **kwargs):
+        if not self._predicate(self._actual, *args, **kwargs):
             predicate_name = self._predicate.__name__
             raise AssertionError('Expected that %s %s, but %s' %
                                  (repr(self._actual),

--- a/tests/unit/test_custom_matchers.py
+++ b/tests/unit/test_custom_matchers.py
@@ -45,3 +45,14 @@ class describe_custom_matchers:
         clear_expectations()
         assert_raises(AttributeError, lambda: expect('potato').is_a_potato)
 
+    def they_can_have_postional_arguments(self):
+        def is_a(thing, vegetable):
+            return thing == vegetable
+        add_expectation(is_a)
+        expect('potato').is_a('potato')
+
+    def they_can_have_keyword_arguments(self):
+        def is_a(thing, vegetable):
+            return thing == vegetable
+        add_expectation(is_a)
+        expect('potato').is_a(vegetable='potato')


### PR DESCRIPTION
This enables expectations like:

```
def was_called_with(dingus, *args, **kwargs):
    return dingus.calls('()', *args, **kwargs)
```
